### PR TITLE
Namespace cleanup

### DIFF
--- a/example/CreateDataProviderExample.php
+++ b/example/CreateDataProviderExample.php
@@ -4,7 +4,7 @@ namespace Potherca\PHPUnit\Example\CreateDataProvider;
 
 class ExampleTest extends \PHPUnit\Framework\TestCase
 {
-    use \Potherca\PhpUnit\CreateDataProviderTrait;
+    use \Potherca\PhpUnit\Traits\CreateDataProviderTrait;
 
     /** @var array */
     private $values = array(

--- a/example/CreateObjectFromAbstractClassExample.php
+++ b/example/CreateObjectFromAbstractClassExample.php
@@ -14,7 +14,7 @@ abstract class AbstractExample
 
 class ExampleTest extends \PHPUnit\Framework\TestCase
 {
-    use \Potherca\PhpUnit\CreateObjectFromAbstractClassTrait;
+    use \Potherca\PhpUnit\Traits\CreateObjectFromAbstractClassTrait;
 
     const MOCK_VALUE = 'mock-value';
 

--- a/example/GetCompatibleExceptionNameExample.php
+++ b/example/GetCompatibleExceptionNameExample.php
@@ -11,7 +11,7 @@ abstract class AbstractTestCase extends \PHPUnit\Framework\TestCase {}
 
 class ExampleTest extends AbstractTestCase
 {
-    use \Potherca\PhpUnit\GetCompatibleExceptionNameTrait;
+    use \Potherca\PhpUnit\Traits\GetCompatibleExceptionNameTrait;
 
     public function testException()
     {

--- a/example/GetNonPublicPropertyExample.php
+++ b/example/GetNonPublicPropertyExample.php
@@ -14,7 +14,7 @@ class Example
 
 class ExampleTest extends \PHPUnit\Framework\TestCase
 {
-    use \Potherca\PhpUnit\GetNonPublicPropertyTrait;
+    use \Potherca\PhpUnit\Traits\GetNonPublicPropertyTrait;
 
     const MOCK_VALUE = 'mock-value';
 

--- a/example/PHP5.3/CreateDataProviderExample.php
+++ b/example/PHP5.3/CreateDataProviderExample.php
@@ -7,7 +7,7 @@ class ExampleTest extends \PHPUnit\Framework\TestCase
     /**
      * As PHP5.3 does not support traits, __call is (a)bused instead of the trait.
      *
-     use \Potherca\PhpUnit\CreateDataProviderTrait;
+     use \Potherca\PhpUnit\Traits\CreateDataProviderTrait;
      *
      * @param string $name
      * @param array $parameters

--- a/example/PHP5.3/CreateObjectFromAbstractClassExample.php
+++ b/example/PHP5.3/CreateObjectFromAbstractClassExample.php
@@ -17,7 +17,7 @@ class ExampleTest extends \PHPUnit\Framework\TestCase
     /**
      * As PHP5.3 does not support traits, __call is (a)bused instead of the trait.
      *
-     use \Potherca\PhpUnit\CreateObjectFromAbstractClassTrait;
+     use \Potherca\PhpUnit\Traits\CreateObjectFromAbstractClassTrait;
      *
      * @param string $name
      * @param array $parameters

--- a/example/PHP5.3/GetCompatibleExceptionNameExample.php
+++ b/example/PHP5.3/GetCompatibleExceptionNameExample.php
@@ -14,7 +14,7 @@ class ExampleTest extends AbstractTestCase
     /**
      * As PHP5.3 does not support traits, __call is (a)bused instead of the trait.
      *
-     use \Potherca\PhpUnit\GetCompatibleExceptionNameTrait;
+     use \Potherca\PhpUnit\Traits\GetCompatibleExceptionNameTrait;
      *
      * @param string $name
      * @param array $parameters

--- a/example/PHP5.3/GetNonPublicPropertyExample.php
+++ b/example/PHP5.3/GetNonPublicPropertyExample.php
@@ -17,7 +17,7 @@ class ExampleTest extends \PHPUnit\Framework\TestCase
     /**
      * As PHP5.3 does not support traits, __call is (a)bused instead of the trait.
      *
-     use \Potherca\PhpUnit\GetNonPublicPropertyTrait;
+     use \Potherca\PhpUnit\Traits\GetNonPublicPropertyTrait;
      *
      * @param string $name
      * @param array $parameters

--- a/example/PHP5.3/SetNonPublicPropertyExample.php
+++ b/example/PHP5.3/SetNonPublicPropertyExample.php
@@ -17,7 +17,7 @@ class ExampleTest extends \PHPUnit\Framework\TestCase
     /**
      * As PHP5.3 does not support traits, __call is (a)bused instead of the trait.
      *
-     use \Potherca\PhpUnit\SetNonPublicPropertyTrait;
+     use \Potherca\PhpUnit\Traits\SetNonPublicPropertyTrait;
      *
      * @param string $name
      * @param array $parameters

--- a/example/SetNonPublicPropertyExample.php
+++ b/example/SetNonPublicPropertyExample.php
@@ -14,7 +14,7 @@ class Example
 
 class ExampleTest extends \PHPUnit\Framework\TestCase
 {
-    use \Potherca\PhpUnit\SetNonPublicPropertyTrait;
+    use \Potherca\PhpUnit\Traits\SetNonPublicPropertyTrait;
 
     const MOCK_VALUE = 'mock-value';
 

--- a/src/InvalidArgumentException.php
+++ b/src/InvalidArgumentException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Potherca\PhpUnit;
+
+class InvalidArgumentException extends \InvalidArgumentException {}
+
+/*EOF*/

--- a/src/Shim/AbstractTraitShim.php
+++ b/src/Shim/AbstractTraitShim.php
@@ -2,6 +2,8 @@
 
 namespace Potherca\PhpUnit\Shim;
 
+use Potherca\PhpUnit\InvalidArgumentException;
+
 abstract class AbstractTraitShim implements TraitShimInterface
 {
     ////////////////////////////// CLASS PROPERTIES \\\\\\\\\\\\\\\\\\\\\\\\\\\\
@@ -24,7 +26,7 @@ abstract class AbstractTraitShim implements TraitShimInterface
     /**
      * @param $testcase \PHPUnit\Framework\TestCase | \PHPUnit_Framework_TestCase
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     final public function __construct($testcase)
     {
@@ -45,7 +47,7 @@ abstract class AbstractTraitShim implements TraitShimInterface
                     $type,
                 )
             );
-            throw new \InvalidArgumentException($message);
+            throw new InvalidArgumentException($message);
         }
 
         $this->testcase = $testcase;
@@ -75,7 +77,7 @@ abstract class AbstractTraitShim implements TraitShimInterface
      *
      * @return string
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     final public function getExistingClassName($class, $alternative = '')
     {
@@ -99,10 +101,10 @@ abstract class AbstractTraitShim implements TraitShimInterface
 
             if ($alternative === '') {
                 $message = vsprintf(
-                    'Could not find class for "%". Both "%s" and "%s" do not exist',
+                    'Could not find class for "%s". Both "%s" and "%s" do not exist',
                     array($class, $nonNamespacedClass, $namespacedClass)
                 );
-                throw new \InvalidArgumentException($message);
+                throw new InvalidArgumentException($message);
             }
 
             $existingClass = $this->getExistingClassName($alternative);

--- a/src/Shim/GetCompatibleExceptionName.php
+++ b/src/Shim/GetCompatibleExceptionName.php
@@ -2,6 +2,8 @@
 
 namespace Potherca\PhpUnit\Shim;
 
+use Potherca\PhpUnit\InvalidArgumentException;
+
 /**
  * @TODO: Add support for `ArithmeticError`
  *
@@ -18,7 +20,7 @@ class GetCompatibleExceptionName extends AbstractTraitShim
      *
      * @return string
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @throws \PHPUnit_Framework_Exception | \PHPUnit\Framework\Exception
      * @throws \PHPUnit_Framework_AssertionFailedError|\PHPUnit\Framework\AssertionFailedError
      * @throws \PHPUnit_Framework_SkippedTestError|\PHPUnit\Framework\SkippedTestError
@@ -29,7 +31,7 @@ class GetCompatibleExceptionName extends AbstractTraitShim
 
         try {
             $exceptionName = $this->getExistingClassName($exceptionName);
-        } catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             // Not an existing class, needs conversion
         }
 
@@ -38,7 +40,7 @@ class GetCompatibleExceptionName extends AbstractTraitShim
         if ($this->isPhpUnitExceptionNeeded($exceptionName) === false) {
             if ($exceptionName === 'DivisionByZeroError') {
                 $this->getTestcase()->expectExceptionMessage('Division by zero');
-                $matchingExceptionName = '\PHPUnit_Framework_Error_Warning';
+                $matchingExceptionName = '\\PHPUnit_Framework_Error_Warning';
             } else {
                 $matchingExceptionName = '\\'.$exceptionName;
             }
@@ -57,8 +59,8 @@ class GetCompatibleExceptionName extends AbstractTraitShim
                 $exceptionName = $this->getMatchingExceptionName($exceptionName);
 
                 $alternative = '';
-                if ($exceptionName === '\PHPUnit_Framework_Error') {
-                    $alternative = 'PHPUnit\Framework\Error\Error';
+                if ($exceptionName === '\\PHPUnit_Framework_Error') {
+                    $alternative = 'PHPUnit\\Framework\\Error\\Error';
                 }
 
                 $matchingExceptionName = $this->getExistingClassName($exceptionName, $alternative);
@@ -93,16 +95,16 @@ class GetCompatibleExceptionName extends AbstractTraitShim
     {
         $matchingExceptions = array(
             // PHP 7.0 thrown when an assertion made via assert() fails.
-            'AssertionError' => '\PHPUnit_Framework_Error_Warning',
+            'AssertionError' => '\\PHPUnit_Framework_Error_Warning',
             // PHP 7.0 thrown when an attempt is made to divide a number by zero.
-            'DivisionByZeroError' => '\PHPUnit_Framework_Error_Warning',
+            'DivisionByZeroError' => '\\PHPUnit_Framework_Error_Warning',
             // PHP 7.0 base class for all internal PHP errors.
-            'Error' => '\PHPUnit_Framework_Error',
+            'Error' => '\\PHPUnit_Framework_Error',
             // PHP 7.0 thrown in one of three circumstances:
             // - an argument type passed to a function does not match the declared parameter type.
             // - a value returned from a function does not match the declared return type.
             // - an invalid number of arguments are passed to a built-in PHP function (strict mode only).
-            'TypeError' => '\PHPUnit_Framework_Error',
+            'TypeError' => '\\PHPUnit_Framework_Error',
         );
 
         if (array_key_exists($exceptionName, $matchingExceptions) === false) {

--- a/src/Shim/GetNonPublicProperty.php
+++ b/src/Shim/GetNonPublicProperty.php
@@ -2,6 +2,8 @@
 
 namespace Potherca\PhpUnit\Shim;
 
+use Potherca\PhpUnit\InvalidArgumentException;
+
 class GetNonPublicProperty extends AbstractTraitShim
 {
 
@@ -18,7 +20,7 @@ class GetNonPublicProperty extends AbstractTraitShim
      *
      * @return mixed
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     final public function getNonPublicProperty($subject, $name)
     {
@@ -35,7 +37,7 @@ class GetNonPublicProperty extends AbstractTraitShim
      *
      * @return \ReflectionProperty
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     final public function getPropertyFromObject($subject, $name)
     {
@@ -49,7 +51,7 @@ class GetNonPublicProperty extends AbstractTraitShim
 
         if ($reflectionProperty === null) {
             $message = vsprintf('Could not find non-public property "%s" in "%s"', array($name, get_class($subject)));
-            throw new \InvalidArgumentException($message);
+            throw new InvalidArgumentException($message);
         }
 
         $reflectionProperty->setAccessible(true);

--- a/src/Shim/SetNonPublicProperty.php
+++ b/src/Shim/SetNonPublicProperty.php
@@ -2,6 +2,8 @@
 
 namespace Potherca\PhpUnit\Shim;
 
+use Potherca\PhpUnit\InvalidArgumentException;
+
 class SetNonPublicProperty extends GetNonPublicProperty
 {
     //////////////////////////////// PUBLIC API \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
@@ -15,7 +17,7 @@ class SetNonPublicProperty extends GetNonPublicProperty
      *
      * @return mixed
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     final public function setNonPublicProperty($subject, $name, $value)
     {

--- a/src/Shim/TraitShimInterface.php
+++ b/src/Shim/TraitShimInterface.php
@@ -2,6 +2,8 @@
 
 namespace Potherca\PhpUnit\Shim;
 
+use Potherca\PhpUnit\InvalidArgumentException;
+
 interface TraitShimInterface
 {
     /**
@@ -12,7 +14,7 @@ interface TraitShimInterface
     /**
      * @param $testcase \PHPUnit\Framework\TestCase | \PHPUnit_Framework_TestCase
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct($testcase);
 
@@ -31,7 +33,7 @@ interface TraitShimInterface
      *
      * @return string
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function getExistingClassName($class);
 }

--- a/src/Shim/Util.php
+++ b/src/Shim/Util.php
@@ -4,7 +4,7 @@ namespace Potherca\PhpUnit\Shim;
 
 class Util
 {
-    const NAMESPACE_PREFIX_LENGTH = 17; // = strlen('Potherca\\PhpUnit\\');
+    const NAMESPACE_PREFIX_LENGTH = 24; // = strlen('Potherca\\PhpUnit\\Traits\\');
     const NAMESPACE_SUFFIX_LENGTH = -5; // = strlen('Trait');
 
     /**

--- a/src/Shim/Util.php
+++ b/src/Shim/Util.php
@@ -4,6 +4,9 @@ namespace Potherca\PhpUnit\Shim;
 
 class Util
 {
+    const NAMESPACE_PREFIX_LENGTH = 17; // = strlen('Potherca\\PhpUnit\\');
+    const NAMESPACE_SUFFIX_LENGTH = -5; // = strlen('Trait');
+
     /**
      * Traits were not introduced until PHP5.4 so for older versions (i.e. PHP5.3)
      * this method loads the trait's functionality. This function should be called
@@ -125,9 +128,7 @@ class Util
             } else {
                 // Only create shim class if native function does not exist
 
-                $start = strlen('Potherca\PhpUnit')+1;
-                $end = -5;  // 5 = "Trait"
-                $name = substr($traitName, $start, $end);
+                $name = substr($traitName, self::NAMESPACE_PREFIX_LENGTH, self::NAMESPACE_SUFFIX_LENGTH);
 
                 $shimClass = vsprintf('%s\\%s', array(__NAMESPACE__, $name));
 

--- a/src/Shim/Util.php
+++ b/src/Shim/Util.php
@@ -2,6 +2,8 @@
 
 namespace Potherca\PhpUnit\Shim;
 
+use Potherca\PhpUnit\InvalidArgumentException;
+
 class Util
 {
     const NAMESPACE_PREFIX_LENGTH = 24; // = strlen('Potherca\\PhpUnit\\Traits\\');
@@ -29,7 +31,7 @@ class Util
      *
      * @return mixed
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     final public static function traitShim($testcase, $functionName, array $parameters)
     {
@@ -52,7 +54,7 @@ class Util
                     $type,
                 )
             );
-            throw new \InvalidArgumentException($message);
+            throw new InvalidArgumentException($message);
         }
 
         $traitShimClass =  __NAMESPACE__.'\\'.ucfirst($functionName);
@@ -98,7 +100,7 @@ class Util
      * @param string $methodName
      * @param string $traitName
      *
-     * @throws \InvalidArgumentException If no Shim class can be found for a given trait
+     * @throws InvalidArgumentException If no Shim class can be found for a given trait
      *
      * @return Callable
      */
@@ -143,7 +145,7 @@ class Util
 
                 if (class_exists($shimClass) === false) {
                     $message = vsprintf('Could not find class "%s" to create for trait "%s"', array($shimClass, $traitName));
-                    throw new \InvalidArgumentException($message);
+                    throw new InvalidArgumentException($message);
                 }
 
                 $implements = class_implements($shimClass);
@@ -154,7 +156,7 @@ class Util
                         'Found class "%s" for trait "%s" but it does not implement "%s"',
                         array($shimClass, $traitName, $interface)
                     );
-                    throw new \InvalidArgumentException($message);
+                    throw new InvalidArgumentException($message);
                 }
 
                 $class[$key] = new $shimClass($testCase);

--- a/src/Traits/CreateDataProviderTrait.php
+++ b/src/Traits/CreateDataProviderTrait.php
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-namespace Potherca\PhpUnit;
+namespace Potherca\PhpUnit\Traits;
 
 /**
  * Creates a "key => [value]" pair from a given one-dimensional array of values,
@@ -33,7 +33,7 @@ namespace Potherca\PhpUnit;
  *
  *    class ExampleTest extends PHPUnit\Framework\TestCase
  *    {
- *        use \Potherca\PhpUnit\CreateDataProviderTrait;
+ *        use \Potherca\PhpUnit\Traits\CreateDataProviderTrait;
  *
  *        public function provideValidValues()
  *        {

--- a/src/Traits/CreateObjectFromAbstractClassTrait.php
+++ b/src/Traits/CreateObjectFromAbstractClassTrait.php
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-namespace Potherca\PhpUnit;
+namespace Potherca\PhpUnit\Traits;
 
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
@@ -43,7 +43,7 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
  *
  *    class AbstractExampleTest extends PHPUnit\Framework\TestCase
  *    {
- *        use \Potherca\PhpUnit\CreateObjectFromAbstractClassTrait;
+ *        use \Potherca\PhpUnit\Traits\CreateObjectFromAbstractClassTrait;
  *
  *        const MOCK_VALUE = 'mock-value';
  *

--- a/src/Traits/GetCompatibleExceptionNameTrait.php
+++ b/src/Traits/GetCompatibleExceptionNameTrait.php
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-namespace Potherca\PhpUnit;
+namespace Potherca\PhpUnit\Traits;
 
 /**
  * Provide names of PHP5 compatible PHPUnit_Framework_Exception for given (new) PHP7 Exceptions.
@@ -42,7 +42,7 @@ namespace Potherca\PhpUnit;
  *
  *    class ExampleTest extends PHPUnit\Framework\TestCase
  *    {
- *        use \Potherca\PhpUnit\GetCompatibleExceptionNameTrait;
+ *        use \Potherca\PhpUnit\Traits\GetCompatibleExceptionNameTrait;
  *
  *        public function testException()
  *        {

--- a/src/Traits/GetNonPublicPropertyTrait.php
+++ b/src/Traits/GetNonPublicPropertyTrait.php
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-namespace Potherca\PhpUnit;
+namespace Potherca\PhpUnit\Traits;
 
 /**
  * Retrieve the value of a non-public property of an object.
@@ -40,7 +40,7 @@ namespace Potherca\PhpUnit;
  *
  *    class ExampleTest extends \PHPUnit\Framework\TestCase
  *    {
- *        use \Potherca\PhpUnit\GetNonPublicPropertyTrait;
+ *        use \Potherca\PhpUnit\Traits\GetNonPublicPropertyTrait;
  *
  *        const MOCK_VALUE = 'mock-value';
  *

--- a/src/Traits/SetNonPublicPropertyTrait.php
+++ b/src/Traits/SetNonPublicPropertyTrait.php
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-namespace Potherca\PhpUnit;
+namespace Potherca\PhpUnit\Traits;
 
 /**
  * Change the value of a non-public property of an object.
@@ -40,7 +40,7 @@ namespace Potherca\PhpUnit;
  *
  *    class ExampleTest extends \PHPUnit\Framework\TestCase
  *    {
- *        use \Potherca\PhpUnit\SetNonPublicPropertyTrait;
+ *        use \Potherca\PhpUnit\Traits\SetNonPublicPropertyTrait;
  *
  *        const MOCK_VALUE = 'mock-value';
  *


### PR DESCRIPTION
Moves traits to separate namespace (and directory) and used namespaced `InvalidArgumentException` instead of global scope exception.