### PR TITLE
Fixes bug caused by inconsistent behaviour in PHP70

### DIFF
--- a/example/GetCompatibleExceptionNameExample.php
+++ b/example/GetCompatibleExceptionNameExample.php
@@ -2,9 +2,12 @@
 
 namespace Potherca\PHPUnit\Example\GetCompatibleExceptionName;
 
+use Potherca\PhpUnit\Shim\GetCompatibleExceptionName;
+
 class Example
 {
     public function __construct(array $value) {}
+    public function example($value) {}
 }
 
 abstract class AbstractTestCase extends \PHPUnit\Framework\TestCase {}
@@ -31,10 +34,10 @@ class ExampleTest extends AbstractTestCase
         1 >> -1;
     }
 
-    public function testArgumentCountError()
+    public function testArgumentCountErrorWithTypeHint()
     {
         // Please note that `\ArgumentCountError::class` is NOT used, as this will cause an error if `ArgumentCountError` does not exist.
-        $exceptionName = $this->getCompatibleExceptionName('\\ArgumentCountError');
+        $exceptionName = $this->getCompatibleExceptionName('\\ArgumentCountError', GetCompatibleExceptionName::ARGUMENT_COUNT_ERROR_WITH_TYPE_HINT);
 
         if (method_exists($this, 'expectExceptionMessageRegExp')) {
             /* PHPUnit ^5.2 | ^6.0 */
@@ -47,6 +50,26 @@ class ExampleTest extends AbstractTestCase
 
         /** @noinspection PhpParamsInspection */
         new Example();
+    }
+
+    public function testArgumentCountErrorWithoutTypeHint()
+    {
+        // Please note that `\ArgumentCountError::class` is NOT used, as this will cause an error if `ArgumentCountError` does not exist.
+        $exceptionName = $this->getCompatibleExceptionName('\\ArgumentCountError', GetCompatibleExceptionName::ARGUMENT_COUNT_ERROR_WITHOUT_TYPE_HINT);
+
+        if (method_exists($this, 'expectExceptionMessageRegExp')) {
+            /* PHPUnit ^5.2 | ^6.0 */
+            $this->expectException($exceptionName);
+            $this->expectExceptionMessageRegExp('/Too few arguments to function|Missing argument 1/');
+        } else {
+            /* PHPUnit ^4.3 | =< 5.6 */
+            $this->setExpectedExceptionRegExp($exceptionName, '/Too few arguments to function|Missing argument 1/');
+        }
+
+        $example = new Example(array());
+
+        /** @noinspection PhpParamsInspection */
+        $example->example();
     }
 
     public function testDivisionByZeroError()

--- a/example/PHP5.3/GetCompatibleExceptionNameExample.php
+++ b/example/PHP5.3/GetCompatibleExceptionNameExample.php
@@ -2,9 +2,12 @@
 
 namespace Potherca\PHPUnit\Example\GetCompatibleExceptionName;
 
+use Potherca\PhpUnit\Shim\GetCompatibleExceptionName;
+
 class Example
 {
     public function __construct(array $value) {}
+    public function example($value) {}
 }
 
 abstract class AbstractTestCase extends \PHPUnit\Framework\TestCase {}
@@ -44,10 +47,10 @@ class ExampleTest extends AbstractTestCase
         1 >> -1;
     }
 
-    public function testArgumentCountError()
+    public function testArgumentCountErrorWithTypeHint()
     {
         // Please note that `\ArgumentCountError::class` is NOT used, as this will cause an error if `ArgumentCountError` does not exist.
-        $exceptionName = $this->getCompatibleExceptionName('\\ArgumentCountError');
+        $exceptionName = $this->getCompatibleExceptionName('\\ArgumentCountError', GetCompatibleExceptionName::ARGUMENT_COUNT_ERROR_WITH_TYPE_HINT);
 
         if (method_exists($this, 'expectExceptionMessageRegExp')) {
             /* PHPUnit ^5.2 | ^6.0 */
@@ -60,6 +63,26 @@ class ExampleTest extends AbstractTestCase
 
         /** @noinspection PhpParamsInspection */
         new Example();
+    }
+
+    public function testArgumentCountErrorWithoutTypeHint()
+    {
+        // Please note that `\ArgumentCountError::class` is NOT used, as this will cause an error if `ArgumentCountError` does not exist.
+        $exceptionName = $this->getCompatibleExceptionName('\\ArgumentCountError', GetCompatibleExceptionName::ARGUMENT_COUNT_ERROR_WITHOUT_TYPE_HINT);
+
+        if (method_exists($this, 'expectExceptionMessageRegExp')) {
+            /* PHPUnit ^5.2 | ^6.0 */
+            $this->expectException($exceptionName);
+            $this->expectExceptionMessageRegExp('/Too few arguments to function|Missing argument 1/');
+        } else {
+            /* PHPUnit ^4.3 | =< 5.6 */
+            $this->setExpectedExceptionRegExp($exceptionName, '/Too few arguments to function|Missing argument 1/');
+        }
+
+        $example = new Example(array());
+
+        /** @noinspection PhpParamsInspection */
+        $example->example();
     }
 
     public function testDivisionByZeroError()

--- a/src/Shim/GetCompatibleExceptionName.php
+++ b/src/Shim/GetCompatibleExceptionName.php
@@ -12,9 +12,13 @@ use Potherca\PhpUnit\InvalidArgumentException;
 class GetCompatibleExceptionName extends AbstractTraitShim
 {
     //////////////////////////////// PUBLIC API \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+    const ARGUMENT_COUNT_ERROR_WITH_TYPE_HINT = 'type-hint';
+    const ARGUMENT_COUNT_ERROR_WITHOUT_TYPE_HINT = 'no-type-hint';
+    const ERROR_CONTEXT_NEEDED = '%s needs a context to decide which exception name to provide. Available options are: "%s"';
 
     /**
      * @param string $exceptionName
+     * @param string $context
      *
      * @return string
      *
@@ -24,7 +28,7 @@ class GetCompatibleExceptionName extends AbstractTraitShim
      * @throws \PHPUnit_Framework_AssertionFailedError|\PHPUnit\Framework\AssertionFailedError
      * @throws \PHPUnit_Framework_SkippedTestError|\PHPUnit\Framework\SkippedTestError
      */
-    final public function getCompatibleExceptionName($exceptionName)
+    final public function getCompatibleExceptionName($exceptionName, $context = '')
     {
         $matchingExceptionName = '';
         $alternative = '';
@@ -48,23 +52,44 @@ class GetCompatibleExceptionName extends AbstractTraitShim
             if ($exceptionName === 'ParseError') {
                 $this->getTestcase()->markTestSkipped('Parse errors can not be caught in PHP5');
             } elseif ($exceptionName === 'ArithmeticError') {
-                /* PHP 7.0 thrown when an error occurs while performing
-                 * mathematical operations. As I have not been able to find the
-                 * PHP5 equivalent, marking as skipped until a working example
-                 * is available
+                /* PHP 7.0 thrown when an error occurs while performing mathematical operations.
+                 * As I have not been able to find the PHP5 equivalent, marking as skipped until
+                 * a working example is available.
                  */
                 $this->getTestcase()->markTestSkipped('There are no equivalent for Arithmetic errors in PHP5 ');
             } elseif ($exceptionName === 'ArgumentCountError') {
-                // PHP 7.1 thrown when too few arguments are passed to a user-defined function or method.
-                // PHP 7.0 throws a TypeError with message 'none given'
-                $matchingExceptionName = $this->getCompatibleExceptionName('\\TypeError');
+                /* PHP 7.1 thrown when too few arguments are passed to a user-defined function or method.
+                 * PHP 7.0 throws a TypeError if a type-hint is present or a warning if no
+                 * type-hint is present. The only way to know which one is needed is to ask the
+                 * calling side.
+                 */
+                $candidates = array(
+                    self::ARGUMENT_COUNT_ERROR_WITH_TYPE_HINT => $this->getCompatibleExceptionName('\\TypeError'),
+                    self::ARGUMENT_COUNT_ERROR_WITHOUT_TYPE_HINT => '\\PHPUnit_Framework_Error',
+                );
+
+                $candidate = self::ARGUMENT_COUNT_ERROR_WITHOUT_TYPE_HINT;
+
+                if (PHP_MAJOR_VERSION.PHP_MINOR_VERSION === '70') {
+                    if (array_key_exists((string) $context, $candidates) === false) {
+                        $exception = $this->getExistingClassName('\\PHPUnit\\Framework\\Exception');
+                        $error = vsprintf(self::ERROR_CONTEXT_NEEDED, array(
+                            'function' => __FUNCTION__,
+                            'candidates' => implode('", "', array_keys($candidates))
+                        ));
+                        throw new $exception($error);
+                    }
+                    $candidate = $context;
+                }
+                $matchingExceptionName = $candidates[$candidate];
             } else {
                 $matchingExceptionName = $this->getMatchingExceptionName($exceptionName);
 
-                if ($matchingExceptionName === '\\PHPUnit_Framework_Error') {
-                    $alternative = '\\PHPUnit\\Framework\\Error\\Error';
-                }
             }
+        }
+
+        if ($matchingExceptionName === '\\PHPUnit_Framework_Error') {
+            $alternative = '\\PHPUnit_Framework_Error_Error';
         }
 
         return $this->getExistingClassName($matchingExceptionName, $alternative);

--- a/src/Traits/GetCompatibleExceptionNameTrait.php
+++ b/src/Traits/GetCompatibleExceptionNameTrait.php
@@ -68,13 +68,14 @@ trait GetCompatibleExceptionNameTrait
 
     /**
      * @param string $exceptionName
+     * @param string $context
      *
      * @return string
      *
      * @throws \PHPUnit_Framework_AssertionFailedError|\PHPUnit\Framework\AssertionFailedError
      * @throws \PHPUnit_Framework_SkippedTestError|\PHPUnit\Framework\SkippedTestError
      */
-    final public function getCompatibleExceptionName($exceptionName)
+    final public function getCompatibleExceptionName($exceptionName, $context = '')
     {
         return call_user_func_array(
             \Potherca\PhpUnit\Shim\Util::createShimForTrait($this,  __FUNCTION__, __TRAIT__),

--- a/tests/unit/Shim/GetCompatibleExceptionNameTest.php
+++ b/tests/unit/Shim/GetCompatibleExceptionNameTest.php
@@ -10,12 +10,133 @@ class GetCompatibleExceptionNameTest  extends AbstractTraitShimTest
 
     /** @noinspection PhpDocMissingThrowsInspection
      *
-     * @dataProvider provideExpectedExceptions
+     * @dataProvider provideExpectedExceptionsWithoutContext
      *
      * @param string $exceptionName
      * @param string|array $expected
      */
-    final public function testShimShouldGetCompatibleExceptionNameWhenGivenExceptionName($exceptionName, $expected)
+    final public function testShimShouldGetCompatibleExceptionNameWhenGivenExceptionNameWithoutContext($exceptionName, $expected)
+    {
+        $expected = $this->getExpectedExceptionFromData($expected);
+
+        $mockTestCase = $this->getMockTestCase();
+
+        $shim = new GetCompatibleExceptionName($mockTestCase);
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $actual = $shim->getCompatibleExceptionName($exceptionName);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /** @noinspection PhpDocMissingThrowsInspection
+     *
+     * @dataProvider provideExpectedExceptionsWithContext
+     *
+     * @param string $exceptionName
+     * @param string|array $expected
+     */
+    final public function testShimShouldComplainWhenGivenExceptionNameWithContext($exceptionName, $expected)
+    {
+        $mockTestCase = $this->getMockTestCase();
+
+        $shim = new GetCompatibleExceptionName($mockTestCase);
+
+        $currentVersion = PHP_MAJOR_VERSION . PHP_MINOR_VERSION;
+
+        if (array_key_exists($currentVersion, $expected) === false) {
+            $this->markTestSkipped('Context not needed for PHP'.$currentVersion);
+        }
+
+        $exception = '\\PHPUnit_Framework_Exception';
+
+        if (class_exists($exception) === false) {
+            $exception = str_replace('_', '\\', $exception);
+        }
+
+        $regex = '/' . vsprintf(GetCompatibleExceptionName::ERROR_CONTEXT_NEEDED, array('.*', '.*')) . '/';
+        if (method_exists($this, 'expectExceptionMessageRegExp')) {
+            /* PHPUnit ^5.2 | ^6.0 */
+            $this->expectExceptionMessageRegExp($regex);
+            $this->expectException($exception);
+        } else {
+            /* PHPUnit ^4.3 | =< 5.6 */
+            $this->setExpectedExceptionRegExp($exception, $regex);
+        }
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $actual = $shim->getCompatibleExceptionName($exceptionName);
+    }
+
+    /** @noinspection PhpDocMissingThrowsInspection
+     *
+     * @dataProvider provideExpectedExceptionsWithContext
+     *
+     * @param string $exceptionName
+     * @param string|array $expected
+     * @param string $context
+     */
+    final public function testShimShouldGetCompatibleExceptionNameWhenGivenExceptionNameWithContext($exceptionName, $expected, $context)
+    {
+        $expected = $this->getExpectedExceptionFromData($expected);
+
+        $mockTestCase = $this->getMockTestCase();
+
+        $shim = new GetCompatibleExceptionName($mockTestCase);
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $actual = $shim->getCompatibleExceptionName($exceptionName, $context);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    ////////////////////////////// MOCKS AND STUBS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+    /////////////////////////////// DATAPROVIDERS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+    public function provideExpectedExceptionsWithContext()
+    {
+        return array(
+            'ArgumentCountError:with type-hint' => array(
+                '\\ArgumentCountError',
+                array(
+                    '5' => '\\PHPUnit_Framework_Error',
+                    '7' => '\\ArgumentCountError',
+                    '70' => '\\TypeError',
+                ),
+                GetCompatibleExceptionName::ARGUMENT_COUNT_ERROR_WITH_TYPE_HINT,
+            ),
+            'ArgumentCountError:without type-hint' => array(
+                '\\ArgumentCountError',
+                array(
+                    '5' => '\\PHPUnit_Framework_Error',
+                    '7' => '\\ArgumentCountError',
+                    '70' => '\\PHPUnit_Framework_Error',
+                ),
+                GetCompatibleExceptionName::ARGUMENT_COUNT_ERROR_WITHOUT_TYPE_HINT,
+            ),
+        );
+    }
+
+    public function provideExpectedExceptionsWithoutContext()
+    {
+        return array(
+            'ArithmeticError' => array('\\ArithmeticError', array(
+                '5' => '\\PHPUnit_Framework_Error',
+                '7' => '\\ArithmeticError',
+            )),
+            'DivisionByZeroError' => array('\\DivisionByZeroError', '\\PHPUnit_Framework_Error_Warning'),
+            'Exception' => array('\\Exception', '\\Exception'),
+            'ParseError' => array('\\ParseError', '\\ParseError'),
+        );
+    }
+
+    /**
+     * @param $expected
+     *
+     * @return mixed
+     */
+    private function getExpectedExceptionFromData($expected)
     {
         if (is_array($expected) === true) {
             /* Grab version specific value */
@@ -28,38 +149,13 @@ class GetCompatibleExceptionNameTest  extends AbstractTraitShimTest
 
         if (class_exists($expected) === false) {
             $expected = str_replace('_', '\\', $expected);
+
+            if ($expected === '\\PHPUnit\\Framework\\Error') {
+                $expected = '\\PHPUnit\\Framework\\Error\\Error';
+            }
         }
 
-        $mockTestCase = $this->getMockTestCase();
-
-        $shim = new GetCompatibleExceptionName($mockTestCase);
-
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $actual = $shim->getCompatibleExceptionName($exceptionName);
-
-        $this->assertSame($expected, $actual);
+        return $expected;
     }
-
-    ////////////////////////////// MOCKS AND STUBS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\
-
-    /////////////////////////////// DATAPROVIDERS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
-
-    public function provideExpectedExceptions()
-    {
-        return array(
-            'ArgumentCountError' => array('\\ArgumentCountError', array(
-                '5' => '\\PHPUnit_Framework_Error',
-                '7' => '\\ArgumentCountError',
-                '70' => '\\TypeError',
-            )),
-            'ArithmeticError' => array('\\ArithmeticError', array(
-                '5' => '\\PHPUnit_Framework_Error',
-                '7' => '\\ArithmeticError',
-            )),
-            'DivisionByZeroError' => array('\\DivisionByZeroError', '\\PHPUnit_Framework_Error_Warning'),
-            'Exception' => array('\\Exception', '\\Exception'),
-        );
-    }
-
 }
 /*EOF*/


### PR DESCRIPTION
Fixes bug in GetCompatibleExceptionName caused by inconsistent behaviour in PHP70.

PHP 7.1 throws a `ArgumentCountError` when too few arguments are passed to a user-defined function or method.

In all PHP 5 versions, an `error` is triggered which can be caught by PHPUnit as `\PHPUnit_Framework_Error` exception.

In PHP 7.0, however there is inconsistent behaviour when a type-hint is present: a TypeError is then thrown.

This PR add the ability to make this distinction by requiring a context to be given for `ArgumentCountError`s in PHP7.0.